### PR TITLE
Got old Version from NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apple-login",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A Apple Log-in Component for React",
   "author": "Mayank Patel <patelmayankce@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
I got an old Version from NPM without React and React-Dome in Version 17 as Dependencies because with the last PR only the Versions changed and not the Version Number of this Package.